### PR TITLE
Review follow-up fixes

### DIFF
--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -67,6 +67,11 @@ class BacktestEngine:
         self._triggers: list[AstRuleTrigger] = []
         self._contexts: dict[str, LocalContext] = {}
 
+    def register_component(self, component: object) -> object:
+        """Keep an event-bus component strongly referenced for the engine lifetime."""
+        self._components.append(component)
+        return component
+
     def register_ast_rule(
         self,
         symbol: str,

--- a/backtest/trade_log.py
+++ b/backtest/trade_log.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -12,6 +13,7 @@ from .models import BacktestResult
 
 BACKTEST_DIR = Path(__file__).parent
 DEFAULT_LOG_DIR = BACKTEST_DIR / "logs"
+LOG_ID_PATTERN = re.compile(r"[a-zA-Z0-9._-]+")
 
 
 def _log_timestamp(path: Path) -> str:
@@ -97,7 +99,7 @@ def _summarize_log_payload(path: Path, payload: dict[str, Any]) -> dict[str, Any
 
 
 def _resolve_log_path(log_id: str, log_dir: Path) -> Path:
-    if "/" in log_id or "\\" in log_id or log_id in {"", ".", ".."}:
+    if log_id in {".", ".."} or not LOG_ID_PATTERN.fullmatch(log_id):
         raise ValueError("Invalid backtest log id")
     path = log_dir / f"{log_id}.json"
     if path.parent != log_dir:

--- a/docs/USER_SIGNAL_GUIDE.md
+++ b/docs/USER_SIGNAL_GUIDE.md
@@ -25,6 +25,7 @@ class Signal:
 
 - Code is executed in-process after AST contract checks.
 - Imports and several dynamic Python constructs are blocked.
+- Double-underscore attribute access such as `().__class__` is blocked before execution.
 - The loader exposes only a small builtin allowlist and `OrderSide`.
 - Runtime errors are captured as diagnostics and do not crash the event bus.
 
@@ -39,7 +40,7 @@ class Signal:
 - `GET /api/signals/live/recent`
 - `GET /api/signals/live/stream`
 
-Live monitoring subscribes to Redis-published `BarEvent` objects on `CEP_REDIS_CHANNEL` (`cep_events` by default). Tick-to-bar aggregation is expected to happen upstream.
+Live monitoring subscribes to JSON-encoded `BarEvent` payloads on `CEP_REDIS_CHANNEL` (`cep_events` by default). Tick-to-bar aggregation is expected to happen upstream. Payloads must include `symbol`, `freq`, OHLCV fields, `turnover`, and ISO-8601 `bar_time`; `event_id` and `timestamp` are optional.
 
 `POST /api/backtests/run-user-signal` also accepts:
 

--- a/frontend/components/BacktestPanel.vue
+++ b/frontend/components/BacktestPanel.vue
@@ -1,21 +1,21 @@
 <template>
-  <section style="margin:0 24px 32px;">
-    <div class="card" style="padding:24px; border-radius:0 0 8px 8px;">
-      <div style="display:flex; justify-content:space-between; gap:24px; flex-wrap:wrap;">
-        <div style="max-width:640px;">
-          <h2 style="font-size:18px; font-weight:700; margin:0 0 6px;">策略回测</h2>
-          <p style="font-size:13px; color:var(--text-muted); line-height:1.6; margin:0;">
+  <section class="backtest-panel">
+    <div class="card backtest-card">
+      <div class="backtest-header">
+        <div class="backtest-heading">
+          <h2 class="backtest-title">策略回测</h2>
+          <p class="backtest-subtitle">
             选择一个预设策略，使用 mock、Tushare 或主连历史库运行事件驱动回测。
           </p>
         </div>
-        <div style="display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap;">
-          <div style="display:inline-flex; border:1px solid var(--border); border-radius:8px; overflow:hidden; background:#fff;">
+        <div class="backtest-actions">
+          <div class="panel-switcher">
             <button type="button" class="btn" :class="activePanel === 'run' ? 'btn-primary' : 'btn-default'"
-              style="border-radius:0; border:0; box-shadow:none;" @click="activePanel = 'run'">
+              @click="activePanel = 'run'">
               运行回测
             </button>
             <button type="button" class="btn" :class="activePanel === 'history' ? 'btn-primary' : 'btn-default'"
-              style="border-radius:0; border:0; box-shadow:none;" @click="activePanel = 'history'; $emit('refresh-history')">
+              @click="activePanel = 'history'; $emit('refresh-history')">
               历史记录
             </button>
           </div>
@@ -30,39 +30,36 @@
 
       <div v-if="activePanel === 'run'" class="backtest-grid">
         <div>
-          <label
-            style="font-size:13px; font-weight:500; color:var(--text-main); display:block; margin-bottom:6px;">预设策略</label>
+          <label class="field-label">预设策略</label>
           <select :value="selectedStrategyId" class="inp"
             @change="$emit('update:selectedStrategyId', ($event.target as HTMLSelectElement).value)">
             <option v-for="preset in backtestPresets" :key="preset.id" :value="preset.id">
               {{ preset.name }}
             </option>
           </select>
-          <div v-if="selectedPreset"
-            style="margin-top:16px; padding:16px; background:#f9fafb; border:1px solid var(--border); border-radius:8px;">
-            <div style="font-size:13px; color:var(--text-muted); line-height:1.6;">
+          <div v-if="selectedPreset" class="preset-summary">
+            <div class="muted-copy">
               {{ selectedPreset.description }}
             </div>
-            <div style="margin-top:14px; display:grid; grid-template-columns:1fr 1fr; gap:10px;">
+            <div class="preset-stat-grid">
               <div>
                 <div class="stat-label">数据集</div>
-                <div style="font-size:14px; font-weight:600;">{{ selectedPreset.dataset }}</div>
+                <div class="stat-text">{{ selectedPreset.dataset }}</div>
               </div>
               <div>
                 <div class="stat-label">标的</div>
-                <div style="font-size:14px; font-weight:600;">{{ formatPresetSymbols(selectedPreset) }}</div>
+                <div class="stat-text">{{ formatPresetSymbols(selectedPreset) }}</div>
               </div>
               <div v-for="param in selectedPresetParameters" :key="param.label">
                 <div class="stat-label">{{ param.label }}</div>
-                <div style="font-size:14px; font-weight:600;">{{ param.value }}</div>
+                <div class="stat-text">{{ param.value }}</div>
               </div>
             </div>
           </div>
 
-          <div style="margin-top:18px; display:flex; flex-direction:column; gap:14px;">
+          <div class="form-stack">
             <div>
-              <label
-                style="font-size:13px; font-weight:500; color:var(--text-main); display:block; margin-bottom:6px;">行情数据源</label>
+              <label class="field-label">行情数据源</label>
               <select :value="backtestDataSource" class="inp"
                 @change="$emit('update:backtestDataSource', ($event.target as HTMLSelectElement).value)">
                 <option value="mock">内置 mock 数据</option>
@@ -75,13 +72,11 @@
               </select>
             </div>
 
-            <div v-if="backtestDataSource === 'tushare' || backtestDataSource === 'adjusted_main_contract'" style="display:flex; flex-direction:column; gap:14px;">
+            <div v-if="backtestDataSource === 'tushare' || backtestDataSource === 'adjusted_main_contract'" class="form-stack compact">
               <div>
-                <label
-                  style="font-size:13px; font-weight:500; color:var(--text-main); display:block; margin-bottom:6px;">{{ backtestDataSource === 'tushare' ? '股票代码' : '主连代码' }}</label>
+                <label class="field-label">{{ backtestDataSource === 'tushare' ? '股票代码' : '主连代码' }}</label>
                 <div class="stock-combobox">
-                  <input type="text" :value="backtestTsCode" class="inp" placeholder="输入代码、简称或公司名"
-                    style="text-transform:uppercase;"
+                  <input type="text" :value="backtestTsCode" class="inp symbol-input" placeholder="输入代码、简称或公司名"
                     @input="$emit('update:backtestTsCode', ($event.target as HTMLInputElement).value)"
                     @focus="backtestDataSource === 'tushare' && $emit('update:stockSearchOpen', stockSearchResults.length > 0)" @blur="$emit('close-stock-search')"
                     @keyup.enter="backtestDataSource === 'tushare' && $emit('search-stocks')" />
@@ -100,21 +95,19 @@
                   </div>
                 </div>
               </div>
-              <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px;">
+              <div class="date-grid">
                 <div>
-                  <label
-                    style="font-size:13px; font-weight:500; color:var(--text-main); display:block; margin-bottom:6px;">开始日期</label>
+                  <label class="field-label">开始日期</label>
                   <input type="date" :value="backtestStartDate" class="inp"
                     @input="$emit('update:backtestStartDate', ($event.target as HTMLInputElement).value)" />
                 </div>
                 <div>
-                  <label
-                    style="font-size:13px; font-weight:500; color:var(--text-main); display:block; margin-bottom:6px;">结束日期</label>
+                  <label class="field-label">结束日期</label>
                   <input type="date" :value="backtestEndDate" class="inp"
                     @input="$emit('update:backtestEndDate', ($event.target as HTMLInputElement).value)" />
                 </div>
               </div>
-              <div style="font-size:12px; color:var(--text-muted); line-height:1.6;">
+              <div class="field-help">
                 {{ backtestDataSource === 'tushare'
                   ? '使用 Tushare daily 未复权日线。需要本机已配置可访问 daily 接口的 token。'
                   : '直接读取本地 adjusted_main_contract CSV 历史数据，代码示例：AU9999.XSGE、IF9999.CCFX。' }}
@@ -124,12 +117,11 @@
         </div>
 
         <div>
-          <div v-if="!backtestResult"
-            style="height:100%; min-height:220px; display:flex; align-items:center; justify-content:center; color:var(--text-muted); background:#f9fafb; border:1px dashed #d1d5db; border-radius:8px;">
+          <div v-if="!backtestResult" class="empty-panel">
             运行回测后查看信号、成交和权益结果
           </div>
 
-          <div v-else style="display:flex; flex-direction:column; gap:20px;">
+          <div v-else class="result-stack">
             <div class="metric-grid">
               <div class="stat-block">
                 <span class="stat-label">最终权益</span>
@@ -158,11 +150,11 @@
               </div>
             </div>
 
-            <div style="overflow-x:auto; border:1px solid var(--border); border-radius:8px;">
+            <div class="table-shell">
               <table>
                 <thead>
                   <tr>
-                    <th style="width:120px;">类型</th>
+                    <th class="type-column">类型</th>
                     <th>时间</th>
                     <th>标的</th>
                     <th>方向</th>
@@ -174,7 +166,7 @@
                 <tbody>
                   <tr v-for="signal in backtestResult.signals" :key="signal.timestamp + signal.payload.side">
                     <td>Signal</td>
-                    <td style="font-size:13px; color:var(--text-muted);">{{ signal.payload.bar_time }}</td>
+                    <td class="muted-cell">{{ signal.payload.bar_time }}</td>
                     <td>{{ signal.symbol }}</td>
                     <td>
                       <span class="badge" :class="signal.payload.side === 'BUY' ? 'badge-vwap' : 'badge-twap'">
@@ -186,7 +178,7 @@
                     <td>{{ signalReference(signal) }}</td>
                   </tr>
                   <tr v-if="backtestResult.signals.length === 0">
-                    <td colspan="7" style="text-align:center; color:var(--text-muted);">没有触发信号</td>
+                    <td colspan="7" class="empty-cell">没有触发信号</td>
                   </tr>
                 </tbody>
               </table>
@@ -195,8 +187,8 @@
         </div>
       </div>
 
-      <div v-else class="backtest-history-grid" style="margin-top:24px;">
-        <div style="overflow-x:auto; border:1px solid var(--border); border-radius:8px;">
+      <div v-else class="backtest-history-grid history-panel">
+        <div class="table-shell">
           <table>
             <thead>
               <tr>
@@ -207,19 +199,19 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="item in backtestHistory" :key="item.id" style="cursor:pointer;"
-                :style="{ background: selectedHistory?.id === item.id ? '#eff6ff' : undefined }"
+              <tr v-for="item in backtestHistory" :key="item.id" class="history-row"
+                :class="{ selected: selectedHistory?.id === item.id }"
                 @click="$emit('select-history', item.id)">
                 <td>
-                  <div style="font-weight:600;">{{ formatDateTime(item.created_at) }}</div>
-                  <div style="font-size:12px; color:var(--text-muted);">{{ item.filename }}</div>
+                  <div class="history-date">{{ formatDateTime(item.created_at) }}</div>
+                  <div class="history-file">{{ item.filename }}</div>
                 </td>
                 <td>{{ formatSymbols(item.symbols) }}</td>
                 <td>{{ formatMoney(item.final_equity) }}</td>
                 <td>{{ item.trade_count }}</td>
               </tr>
               <tr v-if="!backtestHistory.length">
-                <td colspan="4" style="text-align:center; color:var(--text-muted);">
+                <td colspan="4" class="empty-cell">
                   {{ backtestHistoryLoading ? '正在加载历史记录...' : '还没有历史回测日志' }}
                 </td>
               </tr>
@@ -227,7 +219,7 @@
           </table>
         </div>
 
-        <div v-if="selectedHistory" style="display:flex; flex-direction:column; gap:18px;">
+        <div v-if="selectedHistory" class="history-detail">
           <div class="metric-grid">
             <div class="stat-block">
               <span class="stat-label">最终权益</span>
@@ -269,18 +261,18 @@
             </div>
           </div>
 
-          <div style="display:grid; grid-template-columns:repeat(3, 1fr); gap:12px;">
+          <div class="history-meta-grid">
             <div>
               <div class="stat-label">区间开始</div>
-              <div style="font-size:14px; font-weight:600;">{{ formatDateTime(selectedHistory.first_timestamp) }}</div>
+              <div class="stat-text">{{ formatDateTime(selectedHistory.first_timestamp) }}</div>
             </div>
             <div>
               <div class="stat-label">区间结束</div>
-              <div style="font-size:14px; font-weight:600;">{{ formatDateTime(selectedHistory.last_timestamp) }}</div>
+              <div class="stat-text">{{ formatDateTime(selectedHistory.last_timestamp) }}</div>
             </div>
             <div>
               <div class="stat-label">日志路径</div>
-              <div style="font-size:12px; color:var(--text-muted); word-break:break-all;">{{ selectedHistory.path }}</div>
+              <div class="log-path">{{ selectedHistory.path }}</div>
             </div>
           </div>
 
@@ -295,7 +287,7 @@
             </div>
           </div>
 
-          <div style="overflow-x:auto; border:1px solid var(--border); border-radius:8px;">
+          <div class="table-shell">
             <table>
               <thead>
                 <tr>
@@ -308,14 +300,14 @@
               </thead>
               <tbody>
                 <tr v-for="(trade, idx) in latestTrades(selectedHistoryDetail)" :key="idx">
-                  <td style="font-size:13px; color:var(--text-muted);">{{ formatDateTime(asString(trade.timestamp)) }}</td>
+                  <td class="muted-cell">{{ formatDateTime(asString(trade.timestamp)) }}</td>
                   <td>{{ trade.symbol }}</td>
                   <td>{{ trade.side }}</td>
                   <td>{{ trade.quantity }}</td>
                   <td>{{ trade.price }}</td>
                 </tr>
                 <tr v-if="latestTrades(selectedHistoryDetail).length === 0">
-                  <td colspan="5" style="text-align:center; color:var(--text-muted);">
+                  <td colspan="5" class="empty-cell">
                     {{ backtestHistoryDetailLoading ? '正在加载成交详情...' : '没有成交记录' }}
                   </td>
                 </tr>
@@ -323,7 +315,7 @@
             </table>
           </div>
         </div>
-        <div v-else style="min-height:220px; display:flex; align-items:center; justify-content:center; color:var(--text-muted); background:#f9fafb; border:1px dashed #d1d5db; border-radius:8px;">
+        <div v-else class="empty-panel">
           选择一条历史记录查看详情
         </div>
       </div>
@@ -445,3 +437,205 @@ function historyEquityBarHeight(item: BacktestHistoryDetail | null, equity: numb
   return 12 + ((equity - min) / (max - min)) * 88;
 }
 </script>
+
+<style scoped>
+.backtest-panel {
+  margin: 0 24px 32px;
+}
+
+.backtest-card {
+  border-radius: 0 0 8px 8px;
+  padding: 24px;
+}
+
+.backtest-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: space-between;
+}
+
+.backtest-heading {
+  max-width: 640px;
+}
+
+.backtest-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.backtest-subtitle,
+.muted-copy {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.backtest-actions {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.panel-switcher {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: inline-flex;
+  overflow: hidden;
+}
+
+.panel-switcher .btn {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.field-label {
+  color: var(--text-main);
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+}
+
+.preset-summary {
+  background: #f9fafb;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-top: 16px;
+  padding: 16px;
+}
+
+.preset-stat-grid,
+.date-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.preset-stat-grid {
+  margin-top: 14px;
+}
+
+.stat-text {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.form-stack,
+.result-stack,
+.history-detail {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-stack {
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.form-stack.compact {
+  margin-top: 0;
+}
+
+.symbol-input {
+  text-transform: uppercase;
+}
+
+.field-help {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.empty-panel {
+  align-items: center;
+  background: #f9fafb;
+  border: 1px dashed #d1d5db;
+  border-radius: 8px;
+  color: var(--text-muted);
+  display: flex;
+  justify-content: center;
+  min-height: 220px;
+}
+
+.result-stack {
+  gap: 20px;
+}
+
+.table-shell {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.type-column {
+  width: 120px;
+}
+
+.muted-cell {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.empty-cell {
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.history-panel {
+  margin-top: 24px;
+}
+
+.history-row {
+  cursor: pointer;
+}
+
+.history-row.selected {
+  background: #eff6ff;
+}
+
+.history-date {
+  font-weight: 600;
+}
+
+.history-file,
+.log-path {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.history-detail {
+  gap: 18px;
+}
+
+.history-meta-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.log-path {
+  word-break: break-all;
+}
+
+@media (max-width: 720px) {
+  .backtest-panel {
+    margin: 0 12px 24px;
+  }
+
+  .backtest-card {
+    padding: 16px;
+  }
+
+  .date-grid,
+  .history-meta-grid,
+  .preset-stat-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/signals/__init__.py
+++ b/signals/__init__.py
@@ -5,8 +5,10 @@ from .runtime import (
     LiveSignalMonitor,
     SignalContractValidator,
     UserSignalTrigger,
+    deserialize_bar_event_payload,
     load_signal_class,
     run_user_signal_backtest,
+    serialize_bar_event,
     serialize_signal_event,
 )
 
@@ -17,7 +19,9 @@ __all__ = [
     "SignalDiagnostic",
     "SignalStatus",
     "UserSignalTrigger",
+    "deserialize_bar_event_payload",
     "load_signal_class",
     "run_user_signal_backtest",
+    "serialize_bar_event",
     "serialize_signal_event",
 ]

--- a/signals/runtime.py
+++ b/signals/runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 import json
 import logging
-import pickle
 import queue
 import threading
 import time
@@ -13,6 +12,7 @@ from collections import deque
 from datetime import datetime
 from types import MappingProxyType
 from typing import Any, Iterable
+from uuid import uuid4
 
 from backtest.engine import BacktestEngine
 from backtest.preset_strategies import (
@@ -130,6 +130,14 @@ class SignalContractValidator:
                     SignalDiagnostic(
                         level="error",
                         message=f"{type(node).__name__} is not allowed in user signals",
+                        line=getattr(node, "lineno", None),
+                    )
+                )
+            if isinstance(node, ast.Attribute) and node.attr.startswith("__") and node.attr.endswith("__"):
+                diagnostics.append(
+                    SignalDiagnostic(
+                        level="error",
+                        message="dunder attribute access is not allowed in user signals",
                         line=getattr(node, "lineno", None),
                     )
                 )
@@ -478,7 +486,7 @@ def run_user_signal_backtest(
         bar_freq=effective_freq if data_source != "mock" else bar_freq,
     )
     trigger.register()
-    engine._components.append(trigger)
+    engine.register_component(trigger)
     engine.ingest_bars(bars, assume_sorted=True)
     result = engine.run()
     payload = serialize_backtest_result(result)
@@ -506,6 +514,52 @@ def serialize_signal_event(signal: SignalEvent) -> dict[str, Any]:
         "signal_type": signal.signal_type.value,
         "payload": signal.payload,
     }
+
+
+def serialize_bar_event(bar: BarEvent) -> dict[str, Any]:
+    """Convert a BarEvent to a JSON-ready payload for live signal monitoring."""
+
+    return {
+        "event_id": bar.event_id,
+        "timestamp": bar.timestamp.isoformat(),
+        "symbol": bar.symbol,
+        "freq": bar.freq,
+        "open": bar.open,
+        "high": bar.high,
+        "low": bar.low,
+        "close": bar.close,
+        "volume": bar.volume,
+        "turnover": bar.turnover,
+        "bar_time": bar.bar_time.isoformat(),
+    }
+
+
+def deserialize_bar_event_payload(raw_payload: bytes | str) -> BarEvent:
+    """Decode a JSON Redis payload into a BarEvent."""
+
+    if isinstance(raw_payload, bytes):
+        raw_payload = raw_payload.decode("utf-8")
+    payload = json.loads(raw_payload)
+    if not isinstance(payload, dict):
+        raise ValueError("Redis bar payload must be a JSON object")
+    required = {"symbol", "freq", "open", "high", "low", "close", "volume", "turnover", "bar_time"}
+    missing = sorted(required - payload.keys())
+    if missing:
+        raise ValueError(f"Redis bar payload missing fields: {', '.join(missing)}")
+    timestamp = payload.get("timestamp")
+    return BarEvent(
+        event_id=str(payload.get("event_id", "")) or str(uuid4()),
+        timestamp=datetime.fromisoformat(timestamp) if isinstance(timestamp, str) else datetime.utcnow(),
+        symbol=str(payload["symbol"]),
+        freq=str(payload["freq"]),
+        open=float(payload["open"]),
+        high=float(payload["high"]),
+        low=float(payload["low"]),
+        close=float(payload["close"]),
+        volume=int(payload["volume"]),
+        turnover=float(payload["turnover"]),
+        bar_time=datetime.fromisoformat(str(payload["bar_time"])),
+    )
 
 
 class LiveSignalMonitor:
@@ -577,12 +631,11 @@ class LiveSignalMonitor:
                 if message.get("type") != "message":
                     continue
                 try:
-                    event = pickle.loads(message["data"])
+                    event = deserialize_bar_event_payload(message["data"])
                 except Exception as exc:
                     logger.warning("[LiveSignalMonitor] failed to decode Redis event: %s", exc)
                     continue
-                if isinstance(event, BarEvent):
-                    self.publish_bar(event)
+                self.publish_bar(event)
         except Exception as exc:
             logger.error("[LiveSignalMonitor] Redis subscriber exited: %s", exc)
 

--- a/strategy_playground/progress.md
+++ b/strategy_playground/progress.md
@@ -1,6 +1,6 @@
 ## Copper/Silver Ratio -> Oil Strategy Progress
 
-Last updated: 2026-05-01
+Last updated: 2026-05-02
 
 ### Research Goal
 
@@ -47,6 +47,11 @@ The script intentionally keeps only runnable active experiments to preserve futu
 | Soft CU/AG breakout + correlation reversion exit | `next_bar` | 951,200 | -4.88% | -12.40% | -0.221 | 461 | Discard |
 | Soft CU/AG breakout + positive correlation gate | `next_bar` | 998,400 | -0.16% | -9.84% | 0.031 | 268 | Revise |
 | Mid CU/AG breakout + positive correlation gate | `next_bar` | 1,036,760 | 3.68% | -9.57% | 0.254 | 206 | Revise |
+| Mid breakout + corr entry `0.05` | `next_bar` | 942,880 | -5.71% | -12.43% | -0.384 | 118 | Discard |
+| Mid breakout + corr entry `0.10` | `next_bar` | 912,640 | -8.74% | -13.51% | -0.804 | 50 | Discard |
+| Mid breakout + corr entry `0.05`, exit below `0.0` | `next_bar` | 888,990 | -11.10% | -18.51% | -0.634 | 114 | Discard |
+| Mid breakout + corr entry `0.05`, 240-bar hold | `next_bar` | 929,600 | -7.04% | -16.40% | -0.351 | 114 | Discard |
+| Mid breakout + corr entry `0.05`, 480-bar corr window | `next_bar` | 812,610 | -18.74% | -24.53% | -1.115 | 83 | Discard |
 
 ### Timing Validation
 
@@ -67,7 +72,7 @@ The 120-bar minimum-hold variant is the best candidate so far, but it is not pro
 - It still underperforms buy-and-hold SC on total return.
 - It reduces drawdown versus buy-and-hold, but only modestly.
 - The 120-bar minimum hold reduced turnover from roughly `562x` to `472x` notional over the test window, but turnover remains very high.
-- The best breakout/correlation variant so far is the 720-bar breakout with a positive-correlation entry gate: it has lower drawdown and turnover than the min-hold baseline, but still weaker return and Sharpe.
+- The best breakout/correlation variant so far is still the 720-bar breakout with a positive-correlation entry gate. Stricter correlation entry, slower exits, longer holds, and longer correlation windows all failed.
 - Results still assume zero commission and no slippage.
 
 ## Iteration 7
@@ -154,6 +159,38 @@ Current read: the breakout/correlation family is useful as a drawdown and turnov
 
 Next step:
 
-- Raise `corr_entry_threshold` from `0.0` to `0.05` or `0.10`.
-- Keep `breakout_lookback = 720` so only the correlation filter changes.
-- Compare against both `ratio_breakout_mid_corr_gate` and `lagged_ratio_min_hold`.
+- Pause further breakout/correlation tuning after five consecutive failed follow-ups.
+- If revisiting the PMI-lead hypothesis, test a direct ratio acceleration or percentile-thrust feature rather than a higher correlation threshold.
+
+### Follow-Up Sweep: Correlation Quality
+
+Question: can the 720-bar breakout improve if entry correlation is stronger or the correlation-reversion exit is less noisy?
+
+| Variant | Return | Max DD | Sharpe | Trades | Decision |
+|---|---:|---:|---:|---:|---|
+| Entry corr `0.05` | -5.71% | -12.43% | -0.384 | 118 | Discard |
+| Entry corr `0.10` | -8.74% | -13.51% | -0.804 | 50 | Discard |
+| Entry corr `0.05`, exit corr `<0.0` | -11.10% | -18.51% | -0.634 | 114 | Discard |
+| Entry corr `0.05`, 240-bar min hold | -7.04% | -16.40% | -0.351 | 114 | Discard |
+| Entry corr `0.05`, 480-bar corr window | -18.74% | -24.53% | -1.115 | 83 | Discard |
+
+Diagnostics:
+
+- Lookahead/data leakage: all variants used the existing lagged CU/AG ratio update and `next_bar` fills.
+- Trade count: all variants had enough fills to evaluate directionally, except the `0.10` threshold became sparse at 50 fills.
+- Runtime issues: API diagnostics returned `[]` for all five runs.
+- Suspicious behavior: tightening correlation made the system select worse trades. The relation is probably not well represented by contemporaneous rolling correlation.
+
+Decision: DISCARD the stricter-correlation branch.
+
+Online research note:
+
+- S&P Global described copper-user PMI measures as forward-looking for copper demand and prices, including a copper-intensive new-orders/stocks ratio with a reported three-month lead to copper prices.
+- Long-run commodity research by Martin Stuermer finds mineral commodity prices are primarily demand-shock driven, which supports the broader PMI/copper demand premise but not necessarily a minute-level rolling-correlation entry rule.
+
+Sources: [S&P Global copper PMI commentary](https://prod.azure.ihsmarkit.com/marketintelligence/en/mi/research-analysis/pmi-data-indicate-headwinds-to-copper-prices.html), [Cambridge Core commodity price drivers](https://www.cambridge.org/core/journals/macroeconomic-dynamics/article/150-years-of-boom-and-bust-what-drives-mineral-commodity-prices/B037B3EE44D3110E6D67BD4572CE774D).
+
+Next step:
+
+- Keep `ratio_breakout_mid_corr_gate` only as a low-turnover control.
+- For a new PMI-lead experiment, replace correlation gating with CU/AG ratio acceleration or a rolling percentile thrust, then exit on ratio momentum decay.

--- a/tests/test_backtest_api.py
+++ b/tests/test_backtest_api.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timedelta
 
+import pytest
+
 from adapters.flask_app import create_app
 from backtest.preset_strategies import PBX_MA_PRESET_CLOSES
 from backtest.trade_log import list_backtest_trade_logs, read_backtest_trade_log
@@ -369,6 +371,32 @@ def test_backtest_history_api_returns_json_logs(monkeypatch, tmp_path) -> None:
     assert small_detail_response.status_code == 200
     small_detail_payload = small_detail_response.get_json()
     assert len(small_detail_payload["data"]["data"]["equity_curve"]) == 5
+
+
+@pytest.mark.parametrize(
+    "log_id",
+    [
+        "../backtest-20260502T010203-deadbeef",
+        "nested/backtest-20260502T010203-deadbeef",
+        "",
+        ".",
+        "..",
+        "backtest-\x00",
+    ],
+)
+def test_backtest_trade_log_rejects_invalid_log_ids(tmp_path, log_id: str) -> None:
+    with pytest.raises(ValueError, match="Invalid backtest log id"):
+        read_backtest_trade_log(log_id, tmp_path)
+
+
+def test_backtest_trade_log_accepts_whitelisted_log_id(tmp_path) -> None:
+    log_id = "backtest-20260502T010203-deadbeef.v1"
+    (tmp_path / f"{log_id}.json").write_text(json.dumps({"equity_curve": []}), encoding="utf-8")
+
+    payload = read_backtest_trade_log(log_id, tmp_path)
+
+    assert payload is not None
+    assert payload["id"] == log_id
 
 
 def test_stock_search_api_returns_indexed_matches(monkeypatch) -> None:

--- a/tests/test_mock_backtest.py
+++ b/tests/test_mock_backtest.py
@@ -1,4 +1,6 @@
+import gc
 import json
+import weakref
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -35,6 +37,21 @@ def _make_bars(symbol: str, closes: list[float]) -> list[BarEvent]:
         prev_close = close
 
     return bars
+
+
+def test_backtest_engine_register_component_keeps_strong_reference() -> None:
+    class ExternalComponent:
+        pass
+
+    engine = BacktestEngine()
+    component = ExternalComponent()
+    component_ref = weakref.ref(component)
+
+    assert engine.register_component(component) is component
+    del component
+    gc.collect()
+
+    assert component_ref() is not None
 
 
 def test_backtest_engine_processes_market_signal_order_and_trade_flow(monkeypatch, tmp_path) -> None:

--- a/tests/test_user_signals.py
+++ b/tests/test_user_signals.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 
 import pytest
@@ -10,6 +11,7 @@ from signals import (
     load_signal_class,
     run_user_signal_backtest,
 )
+from signals.runtime import deserialize_bar_event_payload, serialize_bar_event
 
 
 VALID_SIGNAL = '''
@@ -64,6 +66,23 @@ def test_loader_blocks_imports():
 
     with pytest.raises(ValueError):
         load_signal_class(source)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "return ().__class__",
+        "return type.__subclasses__()",
+        "return self.__dict__",
+    ],
+)
+def test_validator_blocks_dunder_attribute_access(payload: str) -> None:
+    source = VALID_SIGNAL.replace('return {"side": "BUY", "reason": "oversold", "price": bar.close}', payload)
+
+    is_valid, diagnostics = SignalContractValidator().validate(source)
+
+    assert not is_valid
+    assert any("dunder attribute access" in item.message for item in diagnostics)
 
 
 def test_user_signal_trigger_emits_signal_event():
@@ -253,3 +272,16 @@ class Signal:
 
     assert len(trigger.diagnostics) == 2
     assert all("on_bar failed" in item.message for item in trigger.diagnostics)
+
+
+def test_bar_event_json_payload_round_trips_for_live_monitor() -> None:
+    bar = make_bar(3, 12.5, symbol="AU9999.XSGE")
+
+    decoded = deserialize_bar_event_payload(json.dumps(serialize_bar_event(bar)).encode("utf-8"))
+
+    assert decoded == bar
+
+
+def test_bar_event_json_payload_rejects_missing_required_fields() -> None:
+    with pytest.raises(ValueError, match="missing fields"):
+        deserialize_bar_event_payload(json.dumps({"symbol": "AU9999.XSGE"}))


### PR DESCRIPTION
## Summary

Follow-up work for PR #11 review feedback, plus the latest strategy research progress note already present on `input`.

## Changes

- Harden user-signal validation by rejecting double-underscore attribute access before executing researcher code.
- Replace live signal monitor Redis pickle decoding with JSON payload decoding and explicit `BarEvent` reconstruction helpers.
- Add `BacktestEngine.register_component()` and use it from user-signal backtests instead of reaching into `_components`.
- Validate backtest history log ids with a whitelist instead of blacklist checks.
- Move static inline styles in `BacktestPanel.vue` into scoped classes while keeping data-driven style bindings.
- Update the user-signal guide and add focused tests for the security and API-boundary fixes.
- Update `strategy_playground/progress.md` with the latest strategy research progress.

## Validation

- `PYTHONPATH=. uv run pytest tests/test_user_signals.py tests/test_backtest_api.py tests/test_mock_backtest.py`
- `uv run ruff check signals/runtime.py signals/__init__.py backtest/engine.py backtest/trade_log.py tests/test_user_signals.py tests/test_backtest_api.py tests/test_mock_backtest.py`
- `uv run pyright signals/runtime.py signals/__init__.py backtest/engine.py backtest/trade_log.py tests/test_user_signals.py tests/test_backtest_api.py tests/test_mock_backtest.py`
- `npm run frontend:check`
- `npm run frontend:build`
- `git diff --check`

Repo-wide `ruff` and `pyright` still report pre-existing unrelated issues outside the touched follow-up files.
